### PR TITLE
Fix: GPUSkinController.update() freezing game at launch.

### DIFF
--- a/game/jslib/animation.js
+++ b/game/jslib/animation.js
@@ -1860,7 +1860,26 @@ var GPUSkinController = (function () {
             }
 
             outputMat = md.m43MulTranspose(invBoneLTMs[b], ltm, outputMat);
-            output.setData(outputMat, offset, 12);
+            
+            // output.setData(outputMat, offset, 12);
+            // "output" is a TechniqueParameterBuffer which extends Float32Array
+            // TechniqueParameterBuffer.setData(data, offset, length)
+            // @see https://github.com/turbulenz/turbulenz_engine/blob/403ef0dadbe93aac3122928441cc0cb8b075b1cf/tslib/turbulenz.d.ts#L428
+            // @see https://github.com/turbulenz/turbulenz_engine/blob/403ef0dadbe93aac3122928441cc0cb8b075b1cf/tslib/vmath.ts#L6020
+
+            function _setData(target, buffer, offset, length) {
+                if (offset === undefined) {
+                    offset = 0;
+                };
+                if (length === undefined) {
+                    length = target.length;
+                };
+                for (let i = 0; i < length; i += 1, offset += 1) {
+                    target[offset] = buffer[i];
+                }
+            }
+
+            _setData(output, outputMat, offset, 12);
             offset += 12;
         }
 

--- a/game/jslib/animation.js
+++ b/game/jslib/animation.js
@@ -1860,26 +1860,7 @@ var GPUSkinController = (function () {
             }
 
             outputMat = md.m43MulTranspose(invBoneLTMs[b], ltm, outputMat);
-            
-            // output.setData(outputMat, offset, 12);
-            // "output" is a TechniqueParameterBuffer which extends Float32Array
-            // TechniqueParameterBuffer.setData(data, offset, length)
-            // @see https://github.com/turbulenz/turbulenz_engine/blob/403ef0dadbe93aac3122928441cc0cb8b075b1cf/tslib/turbulenz.d.ts#L428
-            // @see https://github.com/turbulenz/turbulenz_engine/blob/403ef0dadbe93aac3122928441cc0cb8b075b1cf/tslib/vmath.ts#L6020
-
-            function _setData(target, buffer, offset, length) {
-                if (offset === undefined) {
-                    offset = 0;
-                };
-                if (length === undefined) {
-                    length = target.length;
-                };
-                for (let i = 0; i < length; i += 1, offset += 1) {
-                    target[offset] = buffer[i];
-                }
-            }
-
-            _setData(output, outputMat, offset, 12);
+            output.setData(outputMat, offset, 12);
             offset += 12;
         }
 

--- a/game/jslib/webgl/graphicsdevice.js
+++ b/game/jslib/webgl/graphicsdevice.js
@@ -3486,20 +3486,20 @@ var techniqueParameterBufferCreate = function techniqueParameterBufferCreateFn(p
         /* tslint:disable:no-empty */
         Float32Array.prototype.unmap = function techniqueParameterBufferUnmap(writer) {
         };
-
-        /* tslint:enable:no-empty */
-        Float32Array.prototype.setData = function techniqueParameterBufferSetData(data, offset, numValues) {
-            if (offset === undefined) {
-                offset = 0;
-            }
-            if (numValues === undefined) {
-                numValues = this.length;
-            }
-            for (var n = 0; n < numValues; n += 1, offset += 1) {
-                this[offset] = data[n];
-            }
-        };
     }
+
+    /* tslint:enable:no-empty */
+    Float32Array.prototype.setData = function techniqueParameterBufferSetData(data, offset, numValues) {
+        if (offset === undefined) {
+            offset = 0;
+        }
+        if (numValues === undefined) {
+            numValues = this.length;
+        }
+        for (var n = 0; n < numValues; n += 1, offset += 1) {
+            this[offset] = data[n];
+        }
+    };
 
     return new Float32Array(params.numFloats);
 };

--- a/index.html
+++ b/index.html
@@ -502,8 +502,10 @@ TurbulenzEngine.onload = function onloadFn()
                     TurbulenzEngine.onunload.call(this);
                 }
             };  // window.beforeunload
-
-            startCanvas();
+            
+            // @see https://developer.chrome.com/blog/autoplay/
+            // @see https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
+            document.getElementById("engine").addEventListener("click", () => startCanvas(), {once: true});
         };  // window.onload()
 
     </script>


### PR DESCRIPTION
Fixes a runtime error caused by the `GPUSkinController.output` not containing the `.setData()` function implementation.

Tested on:
- Firefox v140.0.4 (aarch64) Linux Flatpak
- Ungoogled-Chromium v138.0.7204.96 (aarch64) Linux Flatpak

Images:
<img width="1920" height="1080" alt="chrome" src="https://github.com/user-attachments/assets/a15e4846-af84-4d67-92c2-a79f358ee6c9" />
<img width="1920" height="1080" alt="firefox" src="https://github.com/user-attachments/assets/392149e2-46f3-42eb-898b-ce4577649229" />

Additional Notes:
I'm aware this is an old project and that this fix is somewhat of a hack, but with the source code being available, I wanted to show it a little love.

